### PR TITLE
Fix setup-helm warning

### DIFF
--- a/.github/workflows/helm-tar-update.yml
+++ b/.github/workflows/helm-tar-update.yml
@@ -12,6 +12,9 @@ jobs:
 
       - name: Prepare Helm
         uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        
       
       - name: Prepare yq
         uses: mikefarah/yq@master


### PR DESCRIPTION
Adds setting token to fix current warning in setup-helm action 

```Warning: Error while fetching latest Helm release: Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`. See https://github.com/octokit/auth-action.js#createactionauth. Using default version v3.9.0```