### PR TITLE
Exclude Chart.lock from git diff

### DIFF
--- a/.github/workflows/helm-tar-update.yml
+++ b/.github/workflows/helm-tar-update.yml
@@ -44,7 +44,7 @@ jobs:
         id: diff-check
         continue-on-error: true
         run: |
-          git diff --cached --exit-code
+          git diff --cached --exit-code ':(exclude)Chart.lock'
 
       - name: setup git config
         if: steps.diff-check.outcome == 'failure'


### PR DESCRIPTION
Lately I've been experiencing some friction when working on Helm charts that use this GitHub action. `helm dependency update` regenerates Chart.lock with a new timestamp on every run, even when the dependencies themselves haven't been updated. This means that every PR ends up with an extra commit that needs to be pulled or rebased. On top of that, every time a different PR is merged to your main branch, it creates a conflict in Chart.lock for every other PR in the repo. If your PR has already been approved and another one is merged, you need to then rebase or resolve the merge conflict, which dismisses the prior approval (because of our repo settings). I've recently had to ask for re-review multiple times on the same PR with no actual changes, which is tedious for both parties and slows things down, especially with people collaborating across time zones.

This change will ignore Chart.lock when performing `git diff`. If there's a real dependency update, Chart.yaml and the compressed charts will change, which means `git diff` will still fail as intended and the change will be committed like normal.

**Current behavior:**

```shell
✔ k8s-central-api % git diff --cached --exit-code
diff --git a/Chart.lock b/Chart.lock
index 109441b..b0f90e2 100644
--- a/Chart.lock
+++ b/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.22.0
 digest: sha256:3a8b07d482c0511e6ea66982eaed84704d4d4b5af358e117aea2f2745461e589
-generated: "2024-08-09T19:48:46.804132237Z"
+generated: "2024-08-09T20:12:20.090506894Z"
1 k8s-central-api %
```

`git diff` exits with a 1 which will cause the action to commit the change, even though the diff is just the timestamp from regenerating Chart.lock.

**New behavior with this change:**

```shell
✔ k8s-central-api % git status
On branch example
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   Chart.lock

✔ k8s-central-api % git diff --cached --exit-code ':(exclude)Chart.lock'
✔ k8s-central-api %      
```

The action will see that `git diff` exited successfully and it won't trigger the new commit to be made.

Here I made an arbitrary version change to a dependency and staged those changes, and in that case the new version correctly exits with a 1:

```shell
✔ k8s-central-api % git status
On branch example
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   Chart.lock
        modified:   Chart.yaml
        new file:   charts/common-2.21.0.tgz
        deleted:    charts/common-2.22.0.tgz

✔ k8s-central-api % git diff --cached --exit-code ':(exclude)Chart.lock'
diff --git a/Chart.yaml b/Chart.yaml
index a91a005..fa08d49 100644
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.x
+    version: 2.21.0
diff --git a/charts/common-2.21.0.tgz b/charts/common-2.21.0.tgz
new file mode 100644
index 0000000..38b4c17
Binary files /dev/null and b/charts/common-2.21.0.tgz differ
diff --git a/charts/common-2.22.0.tgz b/charts/common-2.22.0.tgz
deleted file mode 100644
index aa224c1..0000000
Binary files a/charts/common-2.22.0.tgz and /dev/null differ
1 k8s-central-api %       
```